### PR TITLE
feat: 登録画面3画面（商品・顧客・注文）E2Eテスト拡充

### DIFF
--- a/.kiro/specs/detail-pages-e2e-test/requirements.md
+++ b/.kiro/specs/detail-pages-e2e-test/requirements.md
@@ -1,0 +1,69 @@
+# 登録画面（商品・顧客・注文）E2Eテスト仕様書
+
+## 対象画面
+
+| 画面名 | URL パラメータ | テストファイル |
+|--------|---------------|---------------|
+| 商品登録 | `page=goods-detail` | `tests/tcs/goods-detail.spec.ts` |
+| 顧客登録 | `page=customer-detail` | `tests/tcs/customer-detail.spec.ts` |
+| 注文登録 | `page=sales-detail` | `tests/tcs/sales-detail.spec.ts` |
+
+## 共通仕様
+
+- URL は `process.env.BASE_URL` + `/wp-admin/admin.php?page=xxx-detail` で構築
+- 各テストで `assertPageLoaded()` により `#wpbody-content`、`#wpadminbar` の表示と Fatal error 不在を確認
+- ブラウザは全画面表示 + CSS zoom 75%
+- `WAIT_SEC` 環境変数（1〜3、デフォルト3）で待機秒数を制御
+
+## 商品登録画面（goods-detail）— 3テスト
+
+### テスト1: 画面初期表示・フォーム要素確認
+- `#goods`（商品コード・readonly）、`#goods_name`、`#qty`、`#separately_fg`、`#remark`、`#cmd_regist` の存在確認
+
+### テスト2: 編集可能欄への入力テスト
+- `#goods` は readonly のためスキップ
+- `#goods_name` に「テスト商品」、`#qty` に「10」、`#remark` に「テスト備考」を入力し値を検証
+
+### テスト3: 確認ボタンクリック
+- `#cmd_regist` をクリックし、Fatal error が発生しないこと、`#wpbody-content` が表示されることを確認
+
+## 顧客登録画面（customer-detail）— 4テスト
+
+### テスト1: 画面初期表示・フォーム要素確認
+- `#customer`（顧客コード・readonly）、`#customer_name`、`#tank_0`、`#add_tank_0`、`input[name="goods_s[]"]`（商品チェックボックス群）、`#cmd_regist` の存在確認
+- チェックボックスが1つ以上存在することを検証
+
+### テスト2: 編集可能欄への入力テスト
+- `#customer` は readonly のためスキップ
+- `#customer_name` に「テスト顧客」、`#tank_0` に「テストタンク」を入力し値を検証
+
+### テスト3: 商品チェックボックス操作
+- 先頭のチェックボックスを check → checked 確認 → uncheck → not checked 確認
+
+### テスト4: 追加ボタン・確認ボタンクリック
+- `#add_tank_0`（追加ボタン）クリック → Fatal error なし確認
+- `#cmd_regist`（確認ボタン）クリック → Fatal error なし、`#wpbody-content` 表示確認
+
+## 注文登録画面（sales-detail）— 4テスト
+
+### テスト1: 画面初期表示・フォーム要素確認
+- 以下18要素の存在確認（visible または attached）:
+  - `#sales`（注文番号・readonly）、`#customer`、`#class`、`#cars_tank`（hidden）、`select#goods`、`#ship_addr`、`#field1`、`select#qty`、`#use_stock`、`#delivery_dt`、`#arrival_dt`、`#outgoing_warehouse`、`#repeat_fg`、`#period`、`#span`、`#repeat_s_dt`、`#repeat_e_dt`、`#cmd_regist`
+
+### テスト2: 編集可能欄への入力テスト
+- `#field1` に「テスト備考」を入力し値を検証
+- `#delivery_dt` に「2026-03-01」、`#arrival_dt` に「2026-03-02」を入力し値を検証
+- `#customer` セレクトボックスで2番目のオプションを選択（選択肢が2つ以上ある場合）
+
+### テスト3: チェックボックス操作（label 経由）
+- `#use_stock` — `label.btn[for="use_stock"]` 経由でクリック → checked/unchecked を検証
+- `#repeat_fg` — `label.btn[for="repeat_fg"]` が visible なら label 経由、なければ force クリックで操作
+
+### テスト4: 確認ボタンクリック
+- `#cmd_regist` をクリックし、Fatal error が発生しないこと、`#wpbody-content` が表示されることを確認
+
+## 技術的な発見事項
+
+- `goods`（商品コード）、`customer`（顧客コード）、`sales`（注文番号）の各コード入力欄は `readonly` 属性付き
+- `#cars_tank` 等は `type="hidden"` のため `toBeAttached()` で確認（`toBeVisible()` は不可）
+- 注文登録画面のチェックボックスは `label.btn` 経由でクリックする必要がある（直接クリック不可）

--- a/tests/tcs/customer-detail.spec.ts
+++ b/tests/tcs/customer-detail.spec.ts
@@ -4,20 +4,75 @@ import { assertPageLoaded, wait } from '../../lib/test-helpers';
 const baseUrl = process.env.BASE_URL!;
 const PAGE_URL = `${baseUrl}/wp-admin/admin.php?page=customer-detail`;
 
+// --- フォーム要素ロケーター ---
+const LOCATORS = {
+  customerCode: 'input[name="customer"]#customer',
+  customerName: '#customer_name',
+  tank: '#tank_0',
+  addTankBtn: '#add_tank_0',
+  goodsCheckbox: 'input[name="goods_s[]"]',
+  confirmBtn: '#cmd_regist',
+} as const;
+
 test.describe('顧客登録画面', () => {
-  test('ページが正常に表示される', async ({ page }) => {
+
+  // 要件1: 画面初期表示・フォーム要素確認
+  test('画面が正常に表示されフォーム要素が存在する', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
+
+    await expect(page.locator(LOCATORS.customerCode)).toBeVisible();
+    await expect(page.locator(LOCATORS.customerName)).toBeVisible();
+    await expect(page.locator(LOCATORS.tank)).toBeVisible();
+    await expect(page.locator(LOCATORS.addTankBtn)).toBeVisible();
+    const checkboxCount = await page.locator(LOCATORS.goodsCheckbox).count();
+    expect(checkboxCount).toBeGreaterThan(0);
+    await expect(page.locator(LOCATORS.confirmBtn)).toBeVisible();
+    await wait(page);
   });
 
-  test('「確認」ボタンが存在しクリックできる', async ({ page }) => {
+  // 要件2: フォーム入力テスト（編集可能な欄のみ）
+  test('編集可能なテキスト欄に入力できる', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
 
-    const confirmBtn = page.locator('#wpbody-content input[value="確認"]').first();
-    await expect(confirmBtn).toBeVisible();
-    await confirmBtn.click();
+    // customerCodeはreadonly、それ以外に入力
+    await page.locator(LOCATORS.customerName).fill('テスト顧客');
+    await page.locator(LOCATORS.tank).fill('テストタンク');
     await wait(page);
+
+    await expect(page.locator(LOCATORS.customerName)).toHaveValue('テスト顧客');
+    await expect(page.locator(LOCATORS.tank)).toHaveValue('テストタンク');
+  });
+
+  // 要件3: 商品チェックボックス操作
+  test('商品チェックボックスをクリックできる', async ({ page }) => {
+    await page.goto(PAGE_URL);
+    await assertPageLoaded(page);
+
+    const firstCheckbox = page.locator(LOCATORS.goodsCheckbox).first();
+    await firstCheckbox.check();
+    await wait(page);
+    await expect(firstCheckbox).toBeChecked();
+
+    await firstCheckbox.uncheck();
+    await expect(firstCheckbox).not.toBeChecked();
+  });
+
+  // 要件4: 追加ボタン・確認ボタンクリック
+  test('「追加」「確認」ボタンをクリックしてエラーが発生しない', async ({ page }) => {
+    await page.goto(PAGE_URL);
+    await assertPageLoaded(page);
+
+    await page.locator(LOCATORS.addTankBtn).click();
+    await wait(page);
+    const body1 = await page.locator('body').textContent();
+    expect(body1).not.toContain('Fatal error');
+
+    await page.locator(LOCATORS.confirmBtn).click();
+    await wait(page);
+    const body2 = await page.locator('body').textContent();
+    expect(body2).not.toContain('Fatal error');
     await expect(page.locator('#wpbody-content').first()).toBeVisible();
   });
 });

--- a/tests/tcs/goods-detail.spec.ts
+++ b/tests/tcs/goods-detail.spec.ts
@@ -4,20 +4,58 @@ import { assertPageLoaded, wait } from '../../lib/test-helpers';
 const baseUrl = process.env.BASE_URL!;
 const PAGE_URL = `${baseUrl}/wp-admin/admin.php?page=goods-detail`;
 
+// --- フォーム要素ロケーター ---
+const LOCATORS = {
+  goodsCode: '#goods',
+  goodsName: '#goods_name',
+  qty: '#qty',
+  separatelyFg: '#separately_fg',
+  remark: '#remark',
+  confirmBtn: '#cmd_regist',
+} as const;
+
 test.describe('商品登録画面', () => {
-  test('ページが正常に表示される', async ({ page }) => {
+
+  // 要件1: 画面初期表示・フォーム要素確認
+  test('画面が正常に表示されフォーム要素が存在する', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
+
+    await expect(page.locator(LOCATORS.goodsCode)).toBeVisible();
+    await expect(page.locator(LOCATORS.goodsName)).toBeVisible();
+    await expect(page.locator(LOCATORS.qty)).toBeVisible();
+    await expect(page.locator(LOCATORS.separatelyFg)).toBeAttached();
+    await expect(page.locator(LOCATORS.remark)).toBeVisible();
+    await expect(page.locator(LOCATORS.confirmBtn)).toBeVisible();
+    await wait(page);
   });
 
-  test('「確認」ボタンが存在しクリックできる', async ({ page }) => {
+  // 要件2: フォーム入力テスト（編集可能な欄のみ）
+  test('編集可能なテキスト欄に入力できる', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
 
-    const confirmBtn = page.locator('#wpbody-content input[value="確認"]').first();
-    await expect(confirmBtn).toBeVisible();
-    await confirmBtn.click();
+    // goodsCodeはreadonly、それ以外に入力
+    await page.locator(LOCATORS.goodsName).fill('テスト商品');
+    await page.locator(LOCATORS.qty).fill('10');
+    await page.locator(LOCATORS.remark).fill('テスト備考');
     await wait(page);
+
+    await expect(page.locator(LOCATORS.goodsName)).toHaveValue('テスト商品');
+    await expect(page.locator(LOCATORS.qty)).toHaveValue('10');
+    await expect(page.locator(LOCATORS.remark)).toHaveValue('テスト備考');
+  });
+
+  // 要件3: 確認ボタンクリック
+  test('「確認」ボタンをクリックしてエラーが発生しない', async ({ page }) => {
+    await page.goto(PAGE_URL);
+    await assertPageLoaded(page);
+
+    await page.locator(LOCATORS.confirmBtn).click();
+    await wait(page);
+
+    const body = await page.locator('body').textContent();
+    expect(body).not.toContain('Fatal error');
     await expect(page.locator('#wpbody-content').first()).toBeVisible();
   });
 });

--- a/tests/tcs/sales-detail.spec.ts
+++ b/tests/tcs/sales-detail.spec.ts
@@ -4,20 +4,121 @@ import { assertPageLoaded, wait } from '../../lib/test-helpers';
 const baseUrl = process.env.BASE_URL!;
 const PAGE_URL = `${baseUrl}/wp-admin/admin.php?page=sales-detail`;
 
+// --- フォーム要素ロケーター ---
+const LOCATORS = {
+  salesNo: 'input[name="sales"]#sales',
+  customer: '#customer',
+  carClass: '#class',
+  carsTank: '#cars_tank',
+  goods: 'select#goods',
+  shipAddr: '#ship_addr',
+  field1: '#field1',
+  qty: 'select#qty',
+  useStock: '#use_stock',
+  useStockLabel: 'label.btn[for="use_stock"]',
+  deliveryDt: '#delivery_dt',
+  arrivalDt: '#arrival_dt',
+  outgoingWarehouse: '#outgoing_warehouse',
+  repeatFg: '#repeat_fg',
+  repeatFgLabel: 'label.btn[for="repeat_fg"]',
+  period: '#period',
+  span: '#span',
+  repeatStartDt: '#repeat_s_dt',
+  repeatEndDt: '#repeat_e_dt',
+  confirmBtn: '#cmd_regist',
+} as const;
+
 test.describe('注文登録画面', () => {
-  test('ページが正常に表示される', async ({ page }) => {
+
+  // 要件1: 画面初期表示・フォーム要素確認
+  test('画面が正常に表示されフォーム要素が存在する', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
+
+    await expect(page.locator(LOCATORS.salesNo)).toBeVisible();
+    await expect(page.locator(LOCATORS.customer)).toBeVisible();
+    await expect(page.locator(LOCATORS.carClass)).toBeVisible();
+    await expect(page.locator(LOCATORS.carsTank)).toBeAttached();
+    await expect(page.locator(LOCATORS.goods)).toBeAttached();
+    await expect(page.locator(LOCATORS.shipAddr)).toBeAttached();
+    await expect(page.locator(LOCATORS.qty)).toBeAttached();
+    await expect(page.locator(LOCATORS.outgoingWarehouse)).toBeAttached();
+    await expect(page.locator(LOCATORS.field1)).toBeVisible();
+    await expect(page.locator(LOCATORS.useStock)).toBeAttached();
+    await expect(page.locator(LOCATORS.repeatFg)).toBeAttached();
+    await expect(page.locator(LOCATORS.deliveryDt)).toBeAttached();
+    await expect(page.locator(LOCATORS.arrivalDt)).toBeAttached();
+    await expect(page.locator(LOCATORS.period)).toBeAttached();
+    await expect(page.locator(LOCATORS.span)).toBeAttached();
+    await expect(page.locator(LOCATORS.repeatStartDt)).toBeAttached();
+    await expect(page.locator(LOCATORS.repeatEndDt)).toBeAttached();
+    await expect(page.locator(LOCATORS.confirmBtn)).toBeVisible();
+    await wait(page);
   });
 
-  test('「確認」ボタンが存在しクリックできる', async ({ page }) => {
+  // 要件2: フォーム入力テスト（編集可能な欄のみ）
+  test('編集可能な入力欄に値を設定できる', async ({ page }) => {
     await page.goto(PAGE_URL);
     await assertPageLoaded(page);
 
-    const confirmBtn = page.locator('#wpbody-content input[value="確認"]').first();
-    await expect(confirmBtn).toBeVisible();
-    await confirmBtn.click();
+    // テキストエリア
+    await page.locator(LOCATORS.field1).fill('テスト備考');
+    await expect(page.locator(LOCATORS.field1)).toHaveValue('テスト備考');
+
+    // 日付入力
+    await page.locator(LOCATORS.deliveryDt).fill('2026-03-01');
+    await expect(page.locator(LOCATORS.deliveryDt)).toHaveValue('2026-03-01');
+    await page.locator(LOCATORS.arrivalDt).fill('2026-03-02');
+    await expect(page.locator(LOCATORS.arrivalDt)).toHaveValue('2026-03-02');
+
+    // セレクトボックス（顧客を選択）
+    const customerOptions = await page.locator(`${LOCATORS.customer} option`).count();
+    if (customerOptions > 1) {
+      await page.locator(LOCATORS.customer).selectOption({ index: 1 });
+    }
+
     await wait(page);
+  });
+
+  // 要件3: チェックボックス操作（label経由でクリック）
+  test('チェックボックスをlabel経由で操作できる', async ({ page }) => {
+    await page.goto(PAGE_URL);
+    await assertPageLoaded(page);
+
+    // 在庫使用チェックボックス（labelでクリック）
+    await page.locator(LOCATORS.useStockLabel).click();
+    await wait(page);
+    await expect(page.locator(LOCATORS.useStock)).toBeChecked();
+    await page.locator(LOCATORS.useStockLabel).click();
+    await expect(page.locator(LOCATORS.useStock)).not.toBeChecked();
+
+    // 繰返チェックボックス（labelがあればlabel経由、なければ直接）
+    const repeatLabel = page.locator(LOCATORS.repeatFgLabel);
+    if (await repeatLabel.isVisible()) {
+      await repeatLabel.click();
+      await wait(page);
+      await expect(page.locator(LOCATORS.repeatFg)).toBeChecked();
+      await repeatLabel.click();
+      await expect(page.locator(LOCATORS.repeatFg)).not.toBeChecked();
+    } else {
+      await page.locator(LOCATORS.repeatFg).check({ force: true });
+      await wait(page);
+      await expect(page.locator(LOCATORS.repeatFg)).toBeChecked();
+      await page.locator(LOCATORS.repeatFg).uncheck({ force: true });
+      await expect(page.locator(LOCATORS.repeatFg)).not.toBeChecked();
+    }
+  });
+
+  // 要件4: 確認ボタンクリック
+  test('「確認」ボタンをクリックしてエラーが発生しない', async ({ page }) => {
+    await page.goto(PAGE_URL);
+    await assertPageLoaded(page);
+
+    await page.locator(LOCATORS.confirmBtn).click();
+    await wait(page);
+
+    const body = await page.locator('body').textContent();
+    expect(body).not.toContain('Fatal error');
     await expect(page.locator('#wpbody-content').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## 変更内容

### 商品登録画面（goods-detail）
テストを3件に拡充しました。
1. 画面初期表示・フォーム要素確認 — goods/goods_name/qty/separately_fg/remark/確認ボタン
2. 編集可能欄への入力テスト — goodsCodeはreadonly、それ以外に入力・値検証
3. 確認ボタンクリック — Fatal errorが発生しないことを確認

### 顧客登録画面（customer-detail）
テストを4件に拡充しました。
1. 画面初期表示・フォーム要素確認 — customer/customer_name/tank/追加ボタン/商品チェックボックス群/確認ボタン
2. 編集可能欄への入力テスト — customerCodeはreadonly、それ以外に入力・値検証
3. 商品チェックボックス操作 — check/uncheck動作確認
4. 追加ボタン・確認ボタンクリック — Fatal errorが発生しないことを確認

### 注文登録画面（sales-detail）
テストを4件に拡充しました。
1. 画面初期表示・フォーム要素確認 — 18要素の存在確認（hidden要素はtoBeAttached）
2. 編集可能欄への入力テスト — テキスト/日付/セレクトボックスの入力・値検証
3. チェックボックス操作（label経由） — use_stock/repeat_fgをlabel.btn経由でクリック
4. 確認ボタンクリック — Fatal errorが発生しないことを確認

### 仕様書
- `.kiro/specs/detail-pages-e2e-test/requirements.md` を新規作成

### 技術的な発見事項
- goods/customer/salesのコード入力欄はreadonly属性付き
- `#cars_tank`等はtype="hidden"のためtoBeAttached()で確認
- 注文登録画面のチェックボックスはlabel.btn経由でクリックが必要

### テスト結果
- 全11件パス（WAIT_SEC=1で52.4秒）